### PR TITLE
SECURITY: update link to security team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,4 +5,4 @@ please email a member of the NixOS Security Team and we will ensure the issue
 is handled. Our responses will be signed with our GPG keys.
 
 Please see this page to find the email addresses and more details:
-https://nixos.org/nixos/security.html
+https://nixos.org/community/teams/security.html


### PR DESCRIPTION
The new site layout has moved things about a bit; to make it more obvious where to find the security team's emails, point directly to the Security Team page in the new layout.