### PR TITLE
CODE_OF_CONDUCT: Explicitly state low-quality contributions as negative example

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,6 +20,7 @@ Examples of unacceptable behavior by participants include:
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Wasting other people’s time with low quality contributions, including but not limited to LLM and bot spam
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities


### PR DESCRIPTION
This addition was sparked by someone creating low-quality Rust RFCs using some LLM which wasted a lot of people's time. But here in Nix land too, I think that this is a common enough issue to be worth explicitly writing down.

Some thoughts on the wording:

- LLMs are explicitly mentioned but this is deliberately not exclusive to them. Not only would it otherwise derail into debates about how much LLM output a given text contains or not. Rather, in the end this distinction does not really matter, as humans can sometimes produce texts worse than ChatGPT would.
- On the other hand, LLMs are not explicitly forbidden either. Doing so would probably be a topic of larger discussion which I'm personally not interested in.

My goal is not to change any rules, but merely to clarify current moderation practices with another example.