### PR TITLE
Code of Conduct: Clarify authority and assimilate pledge to RFC 102/NixOS foundation mission statement

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,18 @@
 # Contributor Covenant Code of Conduct
 
-## Our Pledge
+## Our Aim
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest to foster a diverse and welcoming community, we, the moderation team, have adopted this code of conduct as a policy for our actions.
+By [RFC 102](https://github.com/NixOS/rfcs/blob/c65c8321782b40844167beb48818471f70900d9d/rfcs/0102-moderation-team.md),
+
+> the moderation team should utilize the [NixOS Foundation mission](https://nixos.org/community/index.html) and the following statement during their duties:
+>
+>> The NixOS Foundation aims to promote participation without regard to gender,
+sexual orientation, disability, ethnicity, age, or similar personal
+characteristics. We want to strive to create and foster community by providing
+an intentionally welcoming and safe environment where all feel valued and cared
+for, and where all are given opportunity to participate meaningfully. The
+Foundation will work with the community in service of this goal.
 
 ## Our Standards
 


### PR DESCRIPTION
1. The new “Aim” literally cites and therefore mirrors more exactly than the former “Pledge” the guidelines given to the moderation team in [RFC 102](https://github.com/NixOS/rfcs/blob/c65c8321782b40844167beb48818471f70900d9d/rfcs/0102-moderation-team.md).

2. The new phrasing clarifies the authority of the code of conduct: It is a policy the moderation team gave itself.

#### Reasoning:

The actual code of conduct seems reasonable and thus could make moderation decisions more transparent. However, the phrasing of the “Pledge” gave the impression to me and others ([discussion](https://discourse.nixos.org/t/new-code-of-conduct-discussion/35179)) that this document were ruled by the community and every contributor now would have to make this pledge. Such a pledge by the community could only be made via an RFC, as far as I understand.

While making change 2., I noticed that the wording of the “Pledge” expressed essentially the same as the guidelines given in RFC 102. In my opinion, it is more transparent, if these very similar policies for the same thing are also phrased in the same way. Otherwise, the differences might be another source of discussion when arguing about decisions.

If the longer list of traits not to be discriminated is preferable, then, I think, it is also preferable in the mission statement of the NixOS foundation.